### PR TITLE
added regex alert filter avoid CSRF alerts from using upscan correctly

### DIFF
--- a/alert-filters.json
+++ b/alert-filters.json
@@ -10,7 +10,7 @@
     {
       "reason": "Intentional CSRF is expected with Upscan as that is how the service is designed to work",
       "contextId": 1,
-      "url": "http://localhost:12600/advance-valuation-ruling/*upload",
+      "url": "http:\\/\\/localhost:12600\\/advance-valuation-ruling\\/[a-zA-Z0-9]+\\/.*upload.*",
       "ruleId": 10202,
       "newLevel": -1,
       "urlIsRegex": "true"

--- a/alert-filters.json
+++ b/alert-filters.json
@@ -6,6 +6,14 @@
       "url": "http:\/\/localhost:12600\/advance-valuation-ruling\/upload-supporting-documents.*",
       "ruleId": 10202,
       "urlIsRegex": "true"
+    },
+    {
+      "reason": "Intentional CSRF is expected with Upscan as that is how the service is designed to work",
+      "contextId": 1,
+      "url": "http://localhost:12600/advance-valuation-ruling/*upload",
+      "ruleId": 10202,
+      "newLevel": -1,
+      "urlIsRegex": "true"
     }
   ]
 }

--- a/alert-filters.json
+++ b/alert-filters.json
@@ -10,7 +10,7 @@
     {
       "reason": "Intentional CSRF is expected with Upscan as that is how the service is designed to work",
       "contextId": 1,
-      "url": "http:\\/\\/localhost:12600\\/advance-valuation-ruling\\/[a-zA-Z0-9]+\\/.*upload.*",
+      "url": "http:\/\/localhost:12600\/advance-valuation-ruling\/[a-zA-Z0-9]+\/.*upload.*",
       "ruleId": 10202,
       "newLevel": -1,
       "urlIsRegex": "true"


### PR DESCRIPTION
If someone can double-check my regex for the upload urls, that'd be grand.