### PR TITLE
DDCE-4815: Change resource filepaths to URI for Live build

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AgentStepDefs.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/AgentStepDefs.scala
@@ -128,7 +128,7 @@ trait AgentStepDefs
   }
 
   And("I upload the document {string} and continue in Upload letter of authority page") { (filename: String) =>
-    val path = getClass.getResource(s"/testdata/$filename").getPath
+    val path = getClass.getResource(s"/testdata/$filename").toURI.getPath
     UploadLetterOfAuthorityPage
       .loadPage()
       .uploadDocument(path)

--- a/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/StepDefinitions.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/cucumber/stepdefs/StepDefinitions.scala
@@ -162,7 +162,7 @@ class StepDefinitions
   }
 
   And("I upload the document {string} in Upload supporting documents page") { (filePath: String) =>
-    val path = getClass.getResource(s"/testdata/$filePath").getPath
+    val path = getClass.getResource(s"/testdata/$filePath").toURI.getPath
     UploadSupportingDocuments
       .loadPage()
       .uploadDocument(path)


### PR DESCRIPTION
Live service folder has spaces so needed to convert file paths for resource files to URI